### PR TITLE
Job cancellation

### DIFF
--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -200,7 +200,7 @@ module AssessmentAutograde
       e.backtrace.each { |line| COURSE_LOGGER.log(line) }
       return -3, nil
     end
-    
+
 		upload_file_list.each do |f|
 			if !Pathname.new(f["localFile"]).file?
         flash[:error] = "Error while uploading autograding files."
@@ -423,7 +423,7 @@ module AssessmentAutograde
     else
         [handin, makefile, autograde]
     end
-    
+
   end
 
   ##
@@ -500,7 +500,6 @@ module AssessmentAutograde
 			@assessment.problems.each do |p|
         submissions.each do |submission|
           score = submission.scores.find_or_initialize_by(problem_id: p.id)
-          next unless score.new_record? # don't overwrite scores
           score.score = 0
           score.feedback = feedback_str
           score.released = true

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -57,6 +57,24 @@ module AssessmentAutograde
   end
 
   #
+  # cancel - cancel the selected submission by the student or instructor.
+  #
+  # action_auth_level :cancel, :student
+  def cancel
+    @submission = @assessment.submissions.find(params[:submission_id])
+    @effective_cud = @submission.course_user_datum
+
+    unless @assessment.has_autograder?
+      # Not an error, this behavior was specified!
+      flash[:info] = "This submission is not autogradable"
+      redirect_to([:history, @course, @assessment, cud_id: @effective_cud.id]) && return
+    end
+
+    cancelSubmission(@course, @assessment, @submission)
+    redirect_to([:history, @course, @assessment, cud_id: @effective_cud.id]) && return
+  end
+
+  #
   # regradeBatch - regrade the selected submissions by the instructor
   #
   # action_auth_level :regradeBatch, :instructor
@@ -136,6 +154,32 @@ module AssessmentAutograde
     end
 
     redirect_to([@course, @assessment, :submissions]) && return
+  end
+
+  ##
+  # cancelSubmission - submits a cancel request to Tango under the output file
+  # corresponding to the submission.
+  # Returns the response of cancelJob.
+  def cancelSubmission(course, assessment, submission)
+    flash[:error] = "No cancellation request was submitted because the submission is blank" && return if submission.blank?
+    output_file = get_output_file(assessment, submission)
+    status, json_response = tango_cancel(course, assessment, output_file)
+    if status != 0
+      flash[:error] = "Cancellation request failed."
+    else
+      result = json_response['statusId']
+      if result == -1
+        flash[:error] = "Authentication failed."
+      elsif result == -2
+        flash[:error] = "No cancellation request was submitted because no corresponding job was found."
+      elsif result == -3
+        flash[:error] = "No cancellation request was submitted because the job has already finished running."
+      elsif result != 0
+        flash[:error] = "Unknown error in cancellation. Please contact the instructors."
+      else
+        flash[:success] = "Submission cancellation completed successfully."
+      end
+    end
   end
 
   ##
@@ -302,6 +346,20 @@ module AssessmentAutograde
       response = TangoClient.addjob("#{course.name}-#{assessment.name}", job_properties)
     rescue TangoClient::TangoException => e
       flash[:error] = "Error while adding job to the queue: #{e.message}"
+      return -9, nil
+    end
+    [0, response]
+  end
+
+  ##
+  # Makes the Tango cancel request.
+  # Returns 0 on success, and -9 on failure.
+  #
+  def tango_cancel(course, assessment, output_file)
+    begin
+      response = TangoClient.cancel("#{course.name}-#{assessment.name}", output_file)
+    rescue TangoClient::TangoException => e
+      flash[:error] = "Error while cancelling job: #{e.message}"
       return -9, nil
     end
     [0, response]

--- a/app/controllers/assessment/autograde.rb
+++ b/app/controllers/assessment/autograde.rb
@@ -64,9 +64,14 @@ module AssessmentAutograde
     @submission = @assessment.submissions.find(params[:submission_id])
     @effective_cud = @submission.course_user_datum
 
+    unless @cud.instructor? || @cud.id == @effective_cud.id
+      flash[:error] = "No submission found with that id!"
+      redirect_to([@course, @assessment, :submissions]) && return
+    end
+
     unless @assessment.has_autograder?
       # Not an error, this behavior was specified!
-      flash[:info] = "This submission is not autogradable"
+      flash[:info] = "This submission is not cancellable since it was not autograded."
       redirect_to([:history, @course, @assessment, cud_id: @effective_cud.id]) && return
     end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -51,6 +51,7 @@ class AssessmentsController < ApplicationController
 
   # Autograde
   action_no_auth :autograde_done
+  action_auth_level :cancel, :student
   action_auth_level :regrade, :instructor
   action_auth_level :regradeAll, :instructor
   action_no_auth :log_submit

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -5,7 +5,7 @@ require "prawn"
 class SubmissionsController < ApplicationController
   # inherited from ApplicationController
   before_action :set_assessment
-  before_action :set_submission, only: [:destroy, :destroyConfirm, :download, :edit, :listArchive, :update, :view]
+  before_action :set_submission, only: [:cancelConfirm, :destroy, :destroyConfirm, :download, :edit, :listArchive, :update, :view]
   before_action :get_submission_file, only: [:download, :listArchive, :view]
   rescue_from ActionView::MissingTemplate do |exception|
       redirect_to("/home/error_404")
@@ -114,6 +114,15 @@ class SubmissionsController < ApplicationController
   # this is good
   action_auth_level :destroyConfirm, :instructor
   def destroyConfirm
+  end
+
+  # this is also good
+  action_auth_level :cancelConfirm, :student
+  def cancelConfirm
+    if @cud.id != @submission.course_user_datum_id && !@cud.instructor?
+      flash[:error] = "You are not authorized to view this page."
+      redirect_to(course_assessment_submissions_path(@submission.course_user_datum.course, @submission.assessment)) && return
+    end
   end
 
   ##

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -61,13 +61,17 @@
     <td class="smallText">
       <% if @assessment.has_autograder? and submission.version > 0 then %>
         <%= link_to '(Regrade)', [:regrade, @course, @assessment, submission_id: submission.id], method: :post %>
+        <%= link_to '(Cancel)', [:cancel, @course, @assessment, submission_id: submission.id], method: :post %>
       <% end %>
       <%= link_to '(Destroy)', [:destroyConfirm, @course, @assessment, submission] %>
       <%= link_to '(Edit)', [:edit, @course, @assessment, submission] %>
     </td>
 
-    <% if @cud.instructor? %>
-      <td style="color: red;"><%= submission.errors.full_messages.join("<br />") %></td>
-    <% end %>
+    <td style="color: red;"><%= submission.errors.full_messages.join("<br />") %></td>
+  <%# (Ratatouille voice) Anyone can cancel! %>
+  <% elsif @assessment.has_autograder? and submission.version > 0 then %>
+    <td class="smallText">
+      <%= link_to '(Cancel)', [:cancel, @course, @assessment, submission_id: submission.id], method: :post %>
+    </td>
   <% end %>
 </tr>

--- a/app/views/assessments/_submission_history_row.html.erb
+++ b/app/views/assessments/_submission_history_row.html.erb
@@ -61,7 +61,7 @@
     <td class="smallText">
       <% if @assessment.has_autograder? and submission.version > 0 then %>
         <%= link_to '(Regrade)', [:regrade, @course, @assessment, submission_id: submission.id], method: :post %>
-        <%= link_to '(Cancel)', [:cancel, @course, @assessment, submission_id: submission.id], method: :post %>
+        <%= link_to '(Cancel)', [:cancelConfirm, @course, @assessment, submission] %>
       <% end %>
       <%= link_to '(Destroy)', [:destroyConfirm, @course, @assessment, submission] %>
       <%= link_to '(Edit)', [:edit, @course, @assessment, submission] %>
@@ -71,7 +71,7 @@
   <%# (Ratatouille voice) Anyone can cancel! %>
   <% elsif @assessment.has_autograder? and submission.version > 0 then %>
     <td class="smallText">
-      <%= link_to '(Cancel)', [:cancel, @course, @assessment, submission_id: submission.id], method: :post %>
+      <%= link_to '(Cancel)', [:cancelConfirm, @course, @assessment, submission] %>
     </td>
   <% end %>
 </tr>

--- a/app/views/assessments/_submission_history_table.html.erb
+++ b/app/views/assessments/_submission_history_table.html.erb
@@ -27,6 +27,8 @@
         <th>Tweak</th>
         <th></th>
         <th>Errors</th>
+      <% else %>
+	<th></th> <%# For cancellation %>
       <% end %>
 
     </tr>

--- a/app/views/assessments/_submission_summary_row.html.erb
+++ b/app/views/assessments/_submission_summary_row.html.erb
@@ -123,13 +123,13 @@
   <% if @cud.instructor? then %>
       <% if @assessment.has_autograder? and submission.version > 0 then %>
         <%= link_to 'Regrade', [:regrade, @course, @assessment, submission_id: submission.id], {method: :post, class:"btn small"} %>
-        <%= link_to 'Cancel', [:cancel, @course, @assessment, submission_id: submission.id], {method: :post, :class=>"btn small"} %>
+        <%= link_to 'Cancel', [:cancelConfirm, @course, @assessment, submission], {:class=>"btn small"} %>
       <% end %>
       <%= link_to 'Destroy', [:destroyConfirm, @course, @assessment, submission], {:class=>"btn small"} %>
       <%= link_to 'Edit', [:edit, @course, @assessment, submission], {:class=>"btn small"} %>
   <%# Non-instructors should be able to cancel, too. %>
   <% elsif @assessment.has_autograder? and submission.version > 0 then %>
-    <%= link_to 'Cancel', [:cancel, @course, @assessment, submission_id: submission.id], {method: :post, :class=>"btn small"} %>
+    <%= link_to 'Cancel', [:cancelConfirm, @course, @assessment, submission], {:class=>"btn small"} %>
   <% end %>
 
   <% if @cud.instructor? %>

--- a/app/views/assessments/_submission_summary_row.html.erb
+++ b/app/views/assessments/_submission_summary_row.html.erb
@@ -122,12 +122,16 @@
 <br>
   <% if @cud.instructor? then %>
       <% if @assessment.has_autograder? and submission.version > 0 then %>
-        <%= link_to 'Regrade', [:regrade, @course, @assessment, submission_id: submission], {method: :post, class:"btn small"} %>
+        <%= link_to 'Regrade', [:regrade, @course, @assessment, submission_id: submission.id], {method: :post, class:"btn small"} %>
+        <%= link_to 'Cancel', [:cancel, @course, @assessment, submission_id: submission.id], {method: :post, :class=>"btn small"} %>
       <% end %>
       <%= link_to 'Destroy', [:destroyConfirm, @course, @assessment, submission], {:class=>"btn small"} %>
       <%= link_to 'Edit', [:edit, @course, @assessment, submission], {:class=>"btn small"} %>
+  <%# Non-instructors should be able to cancel, too. %>
+  <% elsif @assessment.has_autograder? and submission.version > 0 then %>
+    <%= link_to 'Cancel', [:cancel, @course, @assessment, submission_id: submission.id], {method: :post, :class=>"btn small"} %>
   <% end %>
 
-    <% if @cud.instructor? %>
-      <div style="color: red;"><%= submission.errors.full_messages.join("<br />") %></div>
-    <% end %>
+  <% if @cud.instructor? %>
+    <div style="color: red;"><%= submission.errors.full_messages.join("<br />") %></div>
+  <% end %>

--- a/app/views/jobs/tango_status.html.erb
+++ b/app/views/jobs/tango_status.html.erb
@@ -104,13 +104,17 @@
 <% end %>
 <%= form_tag "tango_prealloc" do %>
     <p><label for="image_dropdown">Pool name:</label>
+    <% if @vm_pool_list.values.length > 0 then %>
     <select id="image_dropdown" name="image">
         <% @vm_pool_list.each do |k, p| %>
         <option value="<%= k %>.img"><%= k %></option>
         <% end %>
     </select></p>
+    <% else %>
+    <input type="text" id="image_dropdown" name="image"></p>
+    <% end %>
     <p><label for="num_instances">Number of instances:</label>
-    <input type="number" name="num" id="num_instances" value="<%= @vm_pool_list.values[0]["total"].length %>"></p>
+    <input type="number" name="num" id="num_instances" value="<%= @vm_pool_list.values.length > 0 ? @vm_pool_list.values[0]["total"].length : 0 %>"></p>
     <input type="submit" class="btn" value="Update number of instances in pool">
 <% end %>
 <h3>Autograding Images in Use</h3>

--- a/app/views/submissions/cancelConfirm.html.erb
+++ b/app/views/submissions/cancelConfirm.html.erb
@@ -1,0 +1,10 @@
+<% if ! @submission then %>
+  No such submission :(
+<% else %>
+  <h2>Cancel <%= @submission.course_user_datum.email %>'s Submission
+#<%=@submission.version%> for <%= @submission.assessment.display_name %></h2>
+  <b>This will cancel this submission from running. The current progress will not be saved, and the submission will not be graded. This action cannot be undone. (If the submission has already finished running, attempting to cancel the submission will have no effect.)</b>
+  <br>
+  <br><br>
+  <%= link_to 'Cancel!', [:cancel, @course, @assessment, submission_id: @submission.id], {:method=>'post', :class=>"btn small"} %>
+<% end %>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -124,15 +124,14 @@
                :title=>"Rerun the autograder on this submission",
                :class=>"btn small regrade-override"} %>
           <%= link_to "<i class='material-icons'>cancel</i>".html_safe,
-              [:cancel, @course, @assessment, submission_id: submission.id],
-              { method: :post,
-               :title=>"Cancel this submission from running",
-               :class=>"btn small"} %>
+              [:cancelConfirm, @course, @assessment, submission],
+              { :title=>"Cancel this submission from running",
+                :class=>"btn small"} %>
         <% end %>
         <%= link_to "<i class='material-icons'>edit</i>".html_safe, [:edit, @course, @assessment, submission],
             {:title=>"Edit the grading properties of this submission",
               :class=>"btn small"} %>
-        <%= link_to "<i class='material-icons'>delete</i>".html_safe, destroyConfirm_course_assessment_submission_path(@course, @assessment, submission),
+        <%= link_to "<i class='material-icons'>delete</i>".html_safe, [:destroyConfirm, @course, @assessment, submission],
             {:title=>"Destroy this submission forever",
               :class=>"btn small"} %>
       </td>

--- a/app/views/submissions/index.html.erb
+++ b/app/views/submissions/index.html.erb
@@ -123,6 +123,11 @@
               { method: :post,
                :title=>"Rerun the autograder on this submission",
                :class=>"btn small regrade-override"} %>
+          <%= link_to "<i class='material-icons'>cancel</i>".html_safe,
+              [:cancel, @course, @assessment, submission_id: submission.id],
+              { method: :post,
+               :title=>"Cancel this submission from running",
+               :class=>"btn small"} %>
         <% end %>
         <%= link_to "<i class='material-icons'>edit</i>".html_safe, [:edit, @course, @assessment, submission],
             {:title=>"Edit the grading properties of this submission",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Autolab3::Application.routes.draw do
 
         # autograde actions
         post "autograde_done"
+        post "cancel"
         post "regrade"
         post "regradeBatch"
         post "regradeAll"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Autolab3::Application.routes.draw do
         resources :scores, only: [:create, :show, :update]
 
         member do
+          get "cancelConfirm"
           get "destroyConfirm"
           get "download"
           get "listArchive", as: :list_archive


### PR DESCRIPTION
Front-end for job cancellation.

Right now, you can cancel a job from three places:

* [The submissions page](http://notolab.ml/courses/Test-Course-V2/assessments/testformsubmission)
* [The submission history page](http://notolab.ml/courses/Test-Course-V2/assessments/testformsubmission/history)
* [The instructor submission management page](http://notolab.ml/courses/Test-Course-V2/assessments/testformsubmission/submissions.html)

The cancellation functionality is available to both students and instructors, but note the checks to ensure that students can't cancel each others' submissions :)

The student is prompted with a confirmation page before the request goes through.

Currently, there's no way to cancel a submission from the `jobs` page, but I can add this if there isn't anything else for me to work on.