### PR TITLE
Grade by max-scoring submission.

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -577,7 +577,9 @@ class AssessmentsController < ApplicationController
 
 
     begin
+      grading_mode_updated = @assessment.grade_latest != edit_assessment_params[:grade_latest]
       flash[:success] = "Saved!" if @assessment.update!(edit_assessment_params)
+      @assessment.update_latest_submissions_modulo_callbacks if grading_mode_updated
 
       redirect_to(tab_index) && return
     rescue ActiveRecord::RecordInvalid => invalid

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -558,7 +558,7 @@ class AssessmentsController < ApplicationController
     params[:active_tab] ||= "basic"
 
     # make sure the 'active_tab' is a real tab
-    unless %w(basic handin penalties problems).include? params[:active_tab]
+    unless %w(basic handin grading problems).include? params[:active_tab]
       params[:active_tab] = "basic"
     end
 
@@ -761,8 +761,8 @@ private
     tab_name = "basic"
     if params[:handin]
       tab_name = "handin"
-    elsif params[:penalties]
-      tab_name = "penalties"
+  elsif params[:grading]
+      tab_name = "grading"
     end
 
     edit_course_assessment_path(@course, @assessment) + "/#tab_"+tab_name

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -387,7 +387,7 @@ private
     s
   end
 
-  GENERAL_SERIALIZABLE = Set.new %w(name display_name category_name description handin_filename handin_directory has_svn has_lang group_size max_grace_days handout writeup max_submissions disable_handins max_size version_threshold embedded_quiz)
+  GENERAL_SERIALIZABLE = Set.new %w(name display_name category_name description handin_filename handin_directory has_svn has_lang group_size max_grace_days handout writeup max_submissions disable_handins max_size version_threshold embedded_quiz grade_latest)
 
   def serialize_general
     Utilities.serializable attributes, GENERAL_SERIALIZABLE
@@ -491,7 +491,8 @@ private
                  "handout_filename" => "handout",
                  "writeup_filename" => "writeup",
                  "has_autograde" => nil,
-                 "has_scoreboard" => nil }
+                 "has_scoreboard" => nil,
+                 "grade_latest" => true }
   BACKWORDS_COMPATIBILITY = { "autograding_setup" => "autograder",
                               "scoreboard_setup" => "scoreboard" }
   def backwards_compatibility(props)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -492,7 +492,7 @@ private
                  "writeup_filename" => "writeup",
                  "has_autograde" => nil,
                  "has_scoreboard" => nil,
-                 "grade_latest" => true }
+                 "grade_latest" => false }
   BACKWORDS_COMPATIBILITY = { "autograding_setup" => "autograder",
                               "scoreboard_setup" => "scoreboard" }
   def backwards_compatibility(props)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -362,7 +362,24 @@ private
   #
   # NOTE: Must be kept in sync with AUD.latest_submission!
   def calculate_latest_submissions
-    submissions.group(:course_user_datum_id).having("MAX(submissions.version)")
+    if grade_latest
+      submissions.group(:course_user_datum_id).having("MAX(submissions.version)")
+    else
+      best = {}
+      for s in submissions
+        key = s.course_user_datum_id
+        best[key] = best[key] ? max_scoring(best[key], s) : s
+      end
+      best.values
+    end
+  end
+
+  def max_scoring(s1, s2)
+    instructor = CourseUserDatum.new
+    instructor.instructor = true
+    score1 = s1.final_score instructor
+    score2 = s2.final_score instructor
+    score1 >= score2 ? s1 : s2
   end
 
   def invalidate_course_cgdubs

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -414,6 +414,7 @@ private
     self.due_at = self.end_at = self.visible_at = self.start_at = self.grading_deadline = Time.now
     self.quiz = false
     self.quizData = ""
+    self.grade_latest = true
     update!(s["general"])
     Problem.deserialize_list(self, s["problems"]) if s["problems"]
     if s["autograder"]
@@ -508,8 +509,7 @@ private
                  "handout_filename" => "handout",
                  "writeup_filename" => "writeup",
                  "has_autograde" => nil,
-                 "has_scoreboard" => nil,
-                 "grade_latest" => false }
+                 "has_scoreboard" => nil }
   BACKWORDS_COMPATIBILITY = { "autograding_setup" => "autograder",
                               "scoreboard_setup" => "scoreboard" }
   def backwards_compatibility(props)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -151,6 +151,13 @@ class Course < ActiveRecord::Base
     assessments.pluck("DISTINCT category_name").sort
   end
 
+  def assessment_grade_by_categories
+    # bool value corresponds to value of "grade_latest" attribute of assessment.
+    { true => "Grade latest submission",
+      false => "Grade max-scoring submission"
+    }
+  end
+
   def assessments_with_category(cat_name, isStudent = false)
     if isStudent
       assessments.where(category_name: cat_name).ordered.released

--- a/app/views/assessments/_edit_grading.html.erb
+++ b/app/views/assessments/_edit_grading.html.erb
@@ -19,5 +19,5 @@
 <%= f.score_adjustment_input :version_penalty, optional: true, help_text: "The penalty applied to submissions with version greater than the version threshold. It represents the number of points or the percentage of the total score removed per version above the threshold, and must be a non-negative number. For example, if this is set to 1 point and the version threshold to 3, the fifth version of a student's submissions would be docked 2 points.", placeholder: "Leave blank to use course default." %>
 
 <div class="action_buttons">
-  <%= f.submit "Save", :name=>"penalties" %>
+  <%= f.submit "Save", :name=>"grading" %>
 </div>

--- a/app/views/assessments/_edit_penalties.html.erb
+++ b/app/views/assessments/_edit_penalties.html.erb
@@ -1,3 +1,12 @@
+<div class="input-field">
+  <%= f.label :grade_latest, { :class=>"control-label active" } %>
+  <%= f.collection_select :grade_latest,
+    @course.assessment_grade_by_categories.to_a, # Convert to "tuples"
+    ->(kvp) { kvp[0] },
+    ->(kvp) { kvp[1] },
+    :selected => @assessment.grade_latest %>
+</div>
+
 <%= f.text_field :max_submissions, help_text: "The maximum number of times a student can submit the assessment.  Set this to -1 to allow unlimited submissions.", placeholder: "E.g. 10" %>
 
 <%= f.text_field :max_grace_days, help_text: "Maximum number of grace days that a student can spend on this assessment. E.g., 2. If left blank, all of the remaining available course grace days can be spent on this assessment.", placeholder: "Leave blank for no grace day limit" %>

--- a/app/views/assessments/edit.html.erb
+++ b/app/views/assessments/edit.html.erb
@@ -28,7 +28,7 @@
 <div class="row">
   <div class="col s12">
     <ul id="tabs" class="tabs tabs-fixed-width">
-    <% [ "basic", "handin", "penalties", "problems" ].each do |tab_name| %>
+    <% [ "basic", "handin", "grading", "problems" ].each do |tab_name| %>
       <%= (tab_name == params[:active_tab]) ? tag(:li, {:class => "active tab"}) : tag(:li, class: :tab) %>
         <%= link_to tab_name.titleize, "#tab_#{tab_name}" %>
       </li>

--- a/app/views/assessments/edit.html.erb
+++ b/app/views/assessments/edit.html.erb
@@ -61,8 +61,8 @@
       <div id="tab_handin">
         <%= render "edit_handin", f: f %>
       </div>
-      <div id="tab_penalties">
-        <%= render "edit_penalties", f: f %>
+      <div id="tab_grading">
+        <%= render "edit_grading", f: f %>
       </div>
       <div id="tab_problems">
         <%= render "edit_problems", f: f %>

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -141,9 +141,11 @@
         </p>
 
         <p class="valign-wrapper">
-          <i class="valign material-icons">today</i>&nbsp;&nbsp;Last day to handin:&nbsp;&nbsp;<b><span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a"> <%= end_at_display(@aud.end_at false) %></span></b>
+          <i class="valign material-icons">today</i>&nbsp;&nbsp;Last day to hand in:&nbsp;&nbsp;<b><span class="moment-date-time" data-format="MMMM Do YYYY, h:mm a"> <%= end_at_display(@aud.end_at false) %></span></b>
 
         </p>
+	<p class="valign-wrapper"><i class="material-icons valign">school</i>&nbsp;&nbsp;Grading strategy:&nbsp;&nbsp;<b>
+   <%= @assessment.grade_latest ? "Latest submission" : "Maximum-scoring submission" %></b></p>
 
         <% if @cud.instructor? and @assessment.exam? %>
         <p class="attention">This is an exam. While it is in progress, please check Admin > Edit Course > Exam In Progress.</p>

--- a/db/migrate/20180822154650_add_grade_latest_to_assessment.rb
+++ b/db/migrate/20180822154650_add_grade_latest_to_assessment.rb
@@ -1,0 +1,5 @@
+class AddGradeLatestToAssessment < ActiveRecord::Migration
+  def change
+    add_column :assessments, :grade_latest, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 20180817214729) do
     t.text     "embedded_quiz_form_data", limit: 65535
     t.boolean  "embedded_quiz",           limit: 1
     t.binary   "embedded_quiz_form"
-    t.boolean  "grade_latest",            limit: 1,     default: false
+    t.boolean  "grade_latest",            limit: 1,     default: true
   end
 
   create_table "attachments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,7 +97,7 @@ ActiveRecord::Schema.define(version: 20180817214729) do
     t.text     "embedded_quiz_form_data", limit: 65535
     t.boolean  "embedded_quiz",           limit: 1
     t.binary   "embedded_quiz_form"
-    t.boolean  "grade_latest",            limit: 1,     default: true
+    t.boolean  "grade_latest",            limit: 1,     default: false
   end
 
   create_table "attachments", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 20180817214729) do
     t.text     "embedded_quiz_form_data", limit: 65535
     t.boolean  "embedded_quiz",           limit: 1
     t.binary   "embedded_quiz_form"
+    t.boolean  "grade_latest",            limit: 1,     default: true
   end
 
   create_table "attachments", force: :cascade do |t|


### PR DESCRIPTION
Allow instructor to choose between grading the max-scoring
submission and the latest submission.

I set the default to scoring by max score, since this is what we want in compilers.

The setting is managed on a per-assessment basis, and can be edited from the normal edit-assessment UI.