### PR TITLE
Streaming feedback for all members

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -530,14 +530,25 @@ class AssessmentsController < ApplicationController
   action_auth_level :viewStreamingFeedback, :student
   def viewStreamingFeedback
     redirect_to(action: "viewFeedback", feedback: params[:feedback], submission_id: params[:submission_id]) && return unless @submission.in_progress
-    output_file = "#{@submission.course_user_datum.email}_#{@submission.version}_#{@assessment.name}_autograde.txt"
-    response = TangoClient.poll("#{@course.name}-#{@assessment.name}", "#{URI.encode(output_file)}", in_progress = 1)
-    # json is returned when a job is not complete
-    if response.content_type == "application/json"
-      @feedback = "Output file not found. The job may not have started yet; see the Jobs page or try again later."
+    # try each group member
+    if group.nil?
+      subs = [@submission]
     else
-      @feedback = response.body
+      subs = @assessment.submissions.where(dave: @submission.dave).all
     end
+
+    subs.each do |sbm|
+      output_file = "#{sbm.course_user_datum.email}_#{sbm.version}_#{@assessment.name}_autograde.txt"
+      response = TangoClient.poll("#{@course.name}-#{@assessment.name}", "#{URI.encode(output_file)}", in_progress = 1)
+      if response.content_type == "application/json"
+        next # try next member
+      else
+        @feedback = response.body
+        return
+      end
+    end
+    # nothing found for all members
+    @feedback = "Output file not found. The job may not have started yet; see the Jobs page or try again later."
   rescue TangoClient::TangoException => e
     @feedback = "Output file not found. The job may not have started yet; see the Jobs page or try again later."
   end


### PR DESCRIPTION
Quick fix so that all group members can view the streaming feedback of submissions regardless of who submitted it.

Background: One problem with Autolab's group feature is that it's simulated with multiple submissions. These separate submissions aren't linked explicitly, and the actual submission that goes to the autograder isn't explicitly marked either. The simplest way to find them is to look for submissions with the same 'dave' key. In fact, this is how the autograder feedback is distributed to all 'child' submissions when autograding completes.

This fix looks up submissions with the same 'dave' key, and polls each one. It's not the most efficient way, but given the scale of the course it should be fine, and it requires the least amount of change.